### PR TITLE
Replace all optimized variants with their C-call counterparts

### DIFF
--- a/src/common_401.cppo.ml
+++ b/src/common_401.cppo.ml
@@ -1,7 +1,14 @@
+#if OCAML_VERSION >= (4, 03, 0)
 external swap16 : int -> int = "%bswap16"
 external swap32 : int32 -> int32 = "%bswap_int32"
 external swap64 : int64 -> int64 = "%bswap_int64"
 external swapnative : nativeint -> nativeint = "%bswap_native"
+#else
+external swap16 : int -> int = "caml_bswap16"
+external swap32 : int32 -> int32 = "caml_int32_bswap"
+external swap64 : int64 -> int64 = "caml_int64_bswap"
+external swapnative : nativeint -> nativeint = "caml_nativeint_bswap"
+#endif
 
 module BigEndian = struct
 

--- a/src/endianBigstring.cppo.ml
+++ b/src/endianBigstring.cppo.ml
@@ -93,7 +93,7 @@ let unsafe_set_char (s:bigstring) off v =
 
 #include "common.ml"
 
-#if OCAML_VERSION >= (4, 01, 0)
+#if OCAML_VERSION >= (4, 03, 0)
 
 external unsafe_get_16 : bigstring -> int -> int = "%caml_bigstring_get16u"
 external unsafe_get_32 : bigstring -> int -> int32 = "%caml_bigstring_get32u"
@@ -110,6 +110,26 @@ external get_64 : bigstring -> int -> int64 = "%caml_bigstring_get64"
 external set_16 : bigstring -> int -> int -> unit = "%caml_bigstring_set16"
 external set_32 : bigstring -> int -> int32 -> unit = "%caml_bigstring_set32"
 external set_64 : bigstring -> int -> int64 -> unit = "%caml_bigstring_set64"
+
+#include "common_401.ml"
+
+#elif OCAML_VERSION >= (4, 01, 0)
+
+external unsafe_get_16 : bigstring -> int -> int = "caml_ba_uint8_get16"
+external unsafe_get_32 : bigstring -> int -> int32 = "caml_ba_uint8_get32"
+external unsafe_get_64 : bigstring -> int -> int64 = "caml_ba_uint8_get64"
+
+external unsafe_set_16 : bigstring -> int -> int -> unit = "caml_ba_uint8_set16"
+external unsafe_set_32 : bigstring -> int -> int32 -> unit = "caml_ba_uint8_set32"
+external unsafe_set_64 : bigstring -> int -> int64 -> unit = "caml_ba_uint8_set64"
+
+external get_16 : bigstring -> int -> int = "caml_ba_uint8_get16"
+external get_32 : bigstring -> int -> int32 = "caml_ba_uint8_get32"
+external get_64 : bigstring -> int -> int64 = "caml_ba_uint8_get64"
+
+external set_16 : bigstring -> int -> int -> unit = "caml_ba_uint8_set16"
+external set_32 : bigstring -> int -> int32 -> unit = "caml_ba_uint8_set32"
+external set_64 : bigstring -> int -> int64 -> unit = "caml_ba_uint8_set64"
 
 #include "common_401.ml"
 

--- a/src/endianBytes.cppo.ml
+++ b/src/endianBytes.cppo.ml
@@ -89,7 +89,7 @@ let unsafe_set_char (s:Bytes.t) off v =
 
 #include "common.ml"
 
-#if OCAML_VERSION >= (4, 01, 0)
+#if OCAML_VERSION >= (4, 03, 0)
 
 external unsafe_get_16 : Bytes.t -> int -> int = "%caml_string_get16u"
 external unsafe_get_32 : Bytes.t -> int -> int32 = "%caml_string_get32u"
@@ -106,6 +106,26 @@ external get_64 : Bytes.t -> int -> int64 = "%caml_string_get64"
 external set_16 : Bytes.t -> int -> int -> unit = "%caml_string_set16"
 external set_32 : Bytes.t -> int -> int32 -> unit = "%caml_string_set32"
 external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64"
+
+#include "common_401.ml"
+
+#elif OCAML_VERSION >= (4, 01, 0)
+
+external unsafe_get_16 : Bytes.t -> int -> int = "caml_string_get16"
+external unsafe_get_32 : Bytes.t -> int -> int32 = "caml_string_get32"
+external unsafe_get_64 : Bytes.t -> int -> int64 = "caml_string_get64"
+
+external unsafe_set_16 : Bytes.t -> int -> int -> unit = "caml_string_set16"
+external unsafe_set_32 : Bytes.t -> int -> int32 -> unit = "caml_string_set32"
+external unsafe_set_64 : Bytes.t -> int -> int64 -> unit = "caml_string_set64"
+
+external get_16 : Bytes.t -> int -> int = "caml_string_get16"
+external get_32 : Bytes.t -> int -> int32 = "caml_string_get32"
+external get_64 : Bytes.t -> int -> int64 = "caml_string_get64"
+
+external set_16 : Bytes.t -> int -> int -> unit = "caml_string_set16"
+external set_32 : Bytes.t -> int -> int32 -> unit = "caml_string_set32"
+external set_64 : Bytes.t -> int -> int64 -> unit = "caml_string_set64"
 
 #include "common_401.ml"
 

--- a/src/endianString.cppo.ml
+++ b/src/endianString.cppo.ml
@@ -85,7 +85,7 @@ let unsafe_set_char (s:Bytes.t) off v =
 
 #include "common.ml"
 
-#if OCAML_VERSION >= (4, 01, 0)
+#if OCAML_VERSION >= (4, 03, 0)
 
 external unsafe_get_16 : string -> int -> int = "%caml_string_get16u"
 external unsafe_get_32 : string -> int -> int32 = "%caml_string_get32u"
@@ -102,6 +102,26 @@ external get_64 : string -> int -> int64 = "%caml_string_get64"
 external set_16 : Bytes.t -> int -> int -> unit = "%caml_string_set16"
 external set_32 : Bytes.t -> int -> int32 -> unit = "%caml_string_set32"
 external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64"
+
+#include "common_401.ml"
+
+#elif OCAML_VERSION >= (4, 01, 0)
+
+external unsafe_get_16 : string -> int -> int = "caml_string_get16"
+external unsafe_get_32 : string -> int -> int32 = "caml_string_get32"
+external unsafe_get_64 : string -> int -> int64 = "caml_string_get64"
+
+external unsafe_set_16 : Bytes.t -> int -> int -> unit = "caml_string_set16"
+external unsafe_set_32 : Bytes.t -> int -> int32 -> unit = "caml_string_set32"
+external unsafe_set_64 : Bytes.t -> int -> int64 -> unit = "caml_string_set64"
+
+external get_16 : string -> int -> int = "caml_string_get16"
+external get_32 : string -> int -> int32 = "caml_string_get32"
+external get_64 : string -> int -> int64 = "caml_string_get64"
+
+external set_16 : Bytes.t -> int -> int -> unit = "caml_string_set16"
+external set_32 : Bytes.t -> int -> int32 -> unit = "caml_string_set32"
+external set_64 : Bytes.t -> int -> int64 -> unit = "caml_string_set64"
 
 #include "common_401.ml"
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -4,10 +4,10 @@ let allocdiff =
   let stat2 = Gc.quick_stat () in
   (stat2.Gc.minor_words -. stat1.Gc.minor_words)
 
-let version_over_4_01 =
+let version_over req_major req_minor =
   try
     Scanf.sscanf Sys.ocaml_version "%i.%i.%i"
-      (fun major minor patch -> major > 4 || (major = 4 && minor >= 1))
+      (fun major minor patch -> major > req_major || (major = req_major && minor >= req_minor))
   with _ -> false
 
 let () =
@@ -40,6 +40,12 @@ let () =
   Printf.printf "bytes: allocated words %f\n%!" alloc3;
   (* we cannot ensure that there are no allocations only with the
      primives added in 4.01.0 *)
-  if version_over_4_01 && (alloc1 <> 0. || alloc2 <> 0. || alloc3 <> 0.)
-  then exit 1
-  else exit 0
+  let failure =
+    if version_over 4 3 then
+      (alloc1 <> 0. || alloc2 <> 0. || alloc3 <> 0.)
+    else if version_over 4 1 then
+      (alloc1 <> 72. || alloc2 <> 72. || alloc3 <> 72.)
+    else
+      false
+  in
+  exit (if failure then 1 else 0)


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=7307
The compiler-provided primitives are dangerous in versions < 4.03,
generating incorrect code. Therefore, revert to the C-call
equivalents.