### PR TITLE
Update Travis CI build OCaml versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=latest TESTS=true PACKAGE=ocplib-endian
+  - OCAML_VERSION=4.07   TESTS=true PACKAGE=ocplib-endian
+  - OCAML_VERSION=4.06   TESTS=true PACKAGE=ocplib-endian
+  - OCAML_VERSION=4.05   TESTS=true PACKAGE=ocplib-endian
   - OCAML_VERSION=4.04   TESTS=true PACKAGE=ocplib-endian
   - OCAML_VERSION=4.03   TESTS=true PACKAGE=ocplib-endian
-  - OCAML_VERSION=4.02   TESTS=true PACKAGE=ocplib-endian
-  - OCAML_VERSION=4.01   TESTS=true PACKAGE=ocplib-endian
-  - OCAML_VERSION=4.00   TESTS=true PACKAGE=ocplib-endian
   - OCAML_VERSION=3.12   TESTS=true PACKAGE=ocplib-endian
 os:
   - linux


### PR DESCRIPTION
Since ocaml-ci-scripts do not support
OCAML_VERSION="latest" anymore, updated the set
of tested compilers, latest being 4.07 one.

Also should fix the failing jobs in https://github.com/OCamlPro/ocplib-endian/pull/14 PR.