### PR TITLE
Fix the implementation for js_of_ocaml

### DIFF
--- a/ocplib-endian.opam
+++ b/ocplib-endian.opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
 doc: "https://ocamlpro.github.io/ocplib-endian/ocplib-endian/"
 depends: [
   "base-bytes"
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "cppo" {>= "1.1.0" & build}
   "dune" {build & >= "1.0"}
 ]

--- a/src/be_ocaml_401.ml
+++ b/src/be_ocaml_401.ml
@@ -4,7 +4,7 @@
     else get_16 s off
 
   let get_int16 s off =
-   ((get_uint16 s off) lsl ( Sys.word_size - 17 )) asr ( Sys.word_size - 17 )
+   ((get_uint16 s off) lsl ( Sys.int_size - 16 )) asr ( Sys.int_size - 16 )
 
   let get_int32 s off =
     if not Sys.big_endian

--- a/src/common.ml
+++ b/src/common.ml
@@ -1,15 +1,15 @@
 [@@@warning "-32"]
 
 let sign8 v =
-  (v lsl ( Sys.word_size - 9 )) asr ( Sys.word_size - 9 )
+  (v lsl ( Sys.int_size - 8 )) asr ( Sys.int_size - 8 )
 
 let sign16 v =
-  (v lsl ( Sys.word_size - 17 )) asr ( Sys.word_size - 17 )
+  (v lsl ( Sys.int_size - 16 )) asr ( Sys.int_size - 16 )
 
 let get_uint8 s off =
   Char.code (get_char s off)
 let get_int8 s off =
-  ((get_uint8 s off) lsl ( Sys.word_size - 9 )) asr ( Sys.word_size - 9 )
+  ((get_uint8 s off) lsl ( Sys.int_size - 8 )) asr ( Sys.int_size - 8 )
 let set_int8 s off v =
   (* It is ok to cast using unsafe_chr because both String.set
      and Bigarray.Array1.set (on bigstrings) use the 'store unsigned int8'
@@ -19,6 +19,6 @@ let set_int8 s off v =
 let unsafe_get_uint8 s off =
   Char.code (unsafe_get_char s off)
 let unsafe_get_int8 s off =
-  ((unsafe_get_uint8 s off) lsl ( Sys.word_size - 9 )) asr ( Sys.word_size - 9 )
+  ((unsafe_get_uint8 s off) lsl ( Sys.int_size - 8 )) asr ( Sys.int_size - 8 )
 let unsafe_set_int8 s off v =
   unsafe_set_char s off (Char.unsafe_chr v)

--- a/src/le_ocaml_401.ml
+++ b/src/le_ocaml_401.ml
@@ -4,7 +4,7 @@
     else get_16 s off
 
   let get_int16 s off =
-   ((get_uint16 s off) lsl ( Sys.word_size - 17 )) asr ( Sys.word_size - 17 )
+   ((get_uint16 s off) lsl ( Sys.int_size - 16 )) asr ( Sys.int_size - 16 )
 
   let get_int32 s off =
     if Sys.big_endian

--- a/src/ne_ocaml_401.ml
+++ b/src/ne_ocaml_401.ml
@@ -2,7 +2,7 @@
     get_16 s off
 
   let get_int16 s off =
-   ((get_uint16 s off) lsl ( Sys.word_size - 17 )) asr ( Sys.word_size - 17 )
+   ((get_uint16 s off) lsl ( Sys.int_size - 16 )) asr ( Sys.int_size - 16 )
 
   let get_int32 s off =
     get_32 s off


### PR DESCRIPTION
Ints are 32bit in jsoo (not 31bit/63bit).

Use Sys.int_size (introduced in OCaml 4.03) instead of making assumption on int size.