### PR TITLE
Remove dependency on base-bytes

### DIFF
--- a/ocplib-endian.opam
+++ b/ocplib-endian.opam
@@ -14,7 +14,6 @@ homepage: "https://github.com/OCamlPro/ocplib-endian"
 bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
 doc: "https://ocamlpro.github.io/ocplib-endian/ocplib-endian/"
 depends: [
-  "base-bytes"
   "ocaml" {>= "4.03.0"}
   "cppo" {>= "1.1.0" & build}
   "dune" {>= "1.0"}

--- a/src/dune
+++ b/src/dune
@@ -62,8 +62,7 @@
  (synopsis "Optimised functions to read and write int16/32/64 from strings and bytes")
  (wrapped false)
  (ocamlopt_flags (:standard -inline 1000))
- (modules endianString endianBytes)
- (libraries bytes))
+ (modules endianString endianBytes))
 
 (library
  (name ocplib_endian_bigstring)
@@ -72,4 +71,4 @@
  (wrapped false)
  (modules endianBigstring)
  (ocamlopt_flags (:standard -inline 1000))
- (libraries ocplib_endian bigarray bytes))
+ (libraries ocplib_endian bigarray))

--- a/tests/dune
+++ b/tests/dune
@@ -17,7 +17,7 @@
  (name tests)
  (wrapped false)
  (modules test_string test_bytes test_bigstring)
- (libraries ocplib-endian ocplib-endian.bigstring bigarray bytes))
+ (libraries ocplib-endian ocplib-endian.bigstring bigarray))
 
 (executables
  (names test)


### PR DESCRIPTION
Bytes has been part of the compiler since 4.02 and that's also the oldest version dune supports.

This also avoids pulling in ocamlfind as a dependency via `base-bytes`, thus making the dependency cone smaller.